### PR TITLE
Disabled Authorization Token for tags api

### DIFF
--- a/api/Conduit.json.postman_collection
+++ b/api/Conduit.json.postman_collection
@@ -1132,7 +1132,8 @@
 							{
 								"key": "Authorization",
 								"value": "Token {{token}}",
-								"description": ""
+								"description": "",
+								"disabled": true
 							}
 						],
 						"body": {},


### PR DESCRIPTION
Was causing the API Call to fail.