### PR TITLE
Fix assertion description in Postman collection

### DIFF
--- a/api/Conduit.postman_collection.json
+++ b/api/Conduit.postman_collection.json
@@ -1554,7 +1554,7 @@
 									"tests['Article has \"favorited\" property'] = article.hasOwnProperty('favorited');",
 									"tests['Article has \"favoritesCount\" property'] = article.hasOwnProperty('favoritesCount');",
 									"tests['favoritesCount is an integer'] = Number.isInteger(article.favoritesCount);",
-									"tests[\"Article's \\\"favorited\\\" property is true\"] = article.favorited === false;",
+									"tests[\"Article's \\\"favorited\\\" property is false\"] = article.favorited === false;",
 									""
 								]
 							}


### PR DESCRIPTION
I fixed an assertion description where it should say `... is false` instead of `... is true`.