### PR TITLE
etc: Dont display stars in ranking comment

### DIFF
--- a/etc/update-readme.js
+++ b/etc/update-readme.js
@@ -80,7 +80,7 @@ async function getSortedTable(repos) {
   output.push('<!--');
   output.push('  Ranking:');
   const repoRankings = repos.map((e, i) => 
-    `    ${(i+1).toString().padStart(2)}: ${e.title} (★ ${e.stargazers_count})`);
+    `    ${(i+1).toString().padStart(2)}: ${e.title}`);
   output.push(...repoRankings);
   output.push('-->');
 


### PR DESCRIPTION
Displaying stars in the ranking comment causes unnecessary updates to README.