### PR TITLE
Dynamically adjust number of example table columns

### DIFF
--- a/etc/update-readme.js
+++ b/etc/update-readme.js
@@ -88,8 +88,8 @@ async function getSortedTable(repos) {
   output.push(...[
     `> _Sorted by popularity on ${(new Date()).toDateString()}_`,
     '',
-    '| 🥇 | 🥈 | 🥉 |',
-    '| :---:         |     :---:      |          :---: |',
+    ['| 🥇 |', ' 🥈 |', ' 🥉 |'].slice(0, repos.length).join(''),
+    ['| :---:         |', '     :---:      |', '          :---: |'].slice(0, repos.length).join(''),
   ]);
 
   // Add sorted table


### PR DESCRIPTION
I was scrolling through the README, and noticed the _Mobile_ examples section could be improved.
![image](https://user-images.githubusercontent.com/8219340/67533963-f1e11500-f699-11e9-9119-959af54a3a45.png)

----

**This adjusts the number of columns in the example tables based on how many examples exist.**

This should improve the look of the tables when there are fewer than 3 examples in a single category.

Specifically, instead of

    | 🥇 | 🥈 | 🥉 |
    | :---:         |     :---:      |          :---: |
    |NativeScript (Angular)



it will render

    | 🥇 |
    | :---:         |
    |NativeScript (Angular)

In the event that two examples exist, it will render

    | 🥇 | 🥈 |
    | :---:         |     :---:      |
    |NativeScript (Angular) |Another (Example)

In the event that there are 3+ examples, it will render normally.