### PR TITLE
add React Native

### DIFF
--- a/etc/mobile-repos.yaml
+++ b/etc/mobile-repos.yaml
@@ -1,3 +1,7 @@
 - title: NativeScript (Angular)
   repo:  nea/nativescript-realworld-example-app
   logo:  https://github.com/nea/nativescript-realworld-example-app/blob/master/logo.png
+- title: React Native
+  repo:  claytonschneider/realworld-react-native
+  logo:  https://github.com/claytonschneider/realworld-react-native/blob/master/reactnative-realworld-logo.png
+

--- a/etc/mobile-repos.yaml
+++ b/etc/mobile-repos.yaml
@@ -4,4 +4,3 @@
 - title: React Native
   repo:  claytonschneider/realworld-react-native
   logo:  https://github.com/claytonschneider/realworld-react-native/blob/master/reactnative-realworld-logo.png
-


### PR DESCRIPTION
I believe [my fork of the repo](https://github.com/NWylynko/realworld-react-native) should be pulled into the repo, it uses the latest versions of react, react native and react navigation. It doesn't use any unnecessary dependencies and has been tested on ios and android. I'm not sure how complete of a project you want before adding it to the list but i've got a good chunk of the spec/api implemented and should get it pretty complete by the end of the week. I can get screenshots but there are some pretty up to date screenshots on my pull request into claytonschneider's repo. 