### PR TITLE
Fixes ISO 8601 timestamp validation

### DIFF
--- a/api/Conduit.postman_collection.json
+++ b/api/Conduit.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0574ad8a-a525-43ae-8e1e-5fd9756037f4",
+		"_postman_id": "aae0c5d4-91ce-4be0-b618-8f89477dee2f",
 		"name": "Conduit",
 		"description": "Collection for testing the Conduit API\n\nhttps://github.com/gothinkster/realworld",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -216,10 +216,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/user",
 							"host": [
@@ -288,7 +284,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Articles",
@@ -299,7 +296,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "9634733c-aa3a-46e0-9dd9-a90e63b86b1d",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -314,14 +311,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -334,7 +332,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -350,10 +349,6 @@
 								"value": "XMLHttpRequest"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles",
 							"host": [
@@ -372,7 +367,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "6fc82d05-3131-4f7f-9f57-1900532fbc01",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -387,14 +382,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -407,7 +403,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -423,10 +420,6 @@
 								"value": "XMLHttpRequest"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?author=johnjacob",
 							"host": [
@@ -451,7 +444,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "73e3a854-5a0f-4f56-b2be-8a24edf7d5db",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -466,14 +459,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -486,7 +480,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -502,10 +497,6 @@
 								"value": "XMLHttpRequest"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?favorited=jane",
 							"host": [
@@ -530,7 +521,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "aadda0bb-ccfd-479f-bdda-ad9050780fd4",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -545,14 +536,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -565,7 +557,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -581,10 +574,6 @@
 								"value": "XMLHttpRequest"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?tag=dragons",
 							"host": [
@@ -603,7 +592,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Articles, Favorite, Comments",
@@ -615,13 +605,13 @@
 							"listen": "test",
 							"script": {
 								"id": "e711dbf8-8065-4ba8-8b74-f1639a7d8208",
-								"type": "text/javascript",
 								"exec": [
 									"var responseJSON = JSON.parse(responseBody);",
 									"",
 									"tests['Response contains \"article\" property'] = responseJSON.hasOwnProperty('article');",
 									"",
 									"var article = responseJSON.article || {};",
+									"var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
@@ -629,9 +619,9 @@
 									"",
 									"tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -640,7 +630,8 @@
 									"tests['Article has \"favoritesCount\" property'] = article.hasOwnProperty('favoritesCount');",
 									"tests['favoritesCount is an integer'] = Number.isInteger(article.favoritesCount);",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -682,7 +673,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "8ce2fb1d-d136-4ce3-9956-c39698d5be08",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -697,14 +688,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -717,7 +709,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -737,10 +730,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles/feed",
 							"host": [
@@ -760,7 +749,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "3c6aa177-6c71-434d-bae5-9d40caec6e82",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -775,14 +764,16 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
+									"        ",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -795,7 +786,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -815,10 +807,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles",
 							"host": [
@@ -837,7 +825,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "bf30b2c8-073a-43fe-ac8c-b916c2518df8",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -852,14 +840,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -872,7 +861,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -892,10 +882,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles",
 							"host": [
@@ -914,7 +900,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "75406b98-ac76-406f-b3d7-aecfcd818746",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -929,14 +915,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -949,7 +936,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -969,10 +957,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?author={{USERNAME}}",
 							"host": [
@@ -997,7 +981,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "ca3bfb1e-3235-4b6e-95ee-eae20c52ffbf",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -1012,14 +996,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1032,7 +1017,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1052,10 +1038,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?author={{USERNAME}}",
 							"host": [
@@ -1080,7 +1062,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "c0f3a361-dc1e-44a0-b229-a667fd59a639",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -1095,14 +1077,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1115,7 +1098,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1135,10 +1119,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?favorited=jane",
 							"host": [
@@ -1163,7 +1143,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "9ccdd927-650a-4475-9a07-9bd47e6635d0",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -1178,14 +1158,15 @@
 									"",
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1198,7 +1179,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1218,10 +1200,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?favorited=jane",
 							"host": [
@@ -1246,21 +1224,22 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "09790781-43f5-4f06-90b4-c1b904c69f76",
 								"exec": [
 									"var responseJSON = JSON.parse(responseBody);",
 									"",
 									"tests['Response contains \"article\" property'] = responseJSON.hasOwnProperty('article');",
 									"",
 									"var article = responseJSON.article || {};",
+									"var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1269,7 +1248,8 @@
 									"tests['Article has \"favoritesCount\" property'] = article.hasOwnProperty('favoritesCount');",
 									"tests['favoritesCount is an integer'] = Number.isInteger(article.favoritesCount);",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1289,10 +1269,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles/{{slug}}",
 							"host": [
@@ -1312,7 +1288,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "bcaa1b82-8a52-49e3-bef9-2d7ba912738e",
 								"exec": [
 									"var is200Response = responseCode.code === 200;",
 									"",
@@ -1328,13 +1304,15 @@
 									"    if(responseJSON.articles.length){",
 									"        var article = responseJSON.articles[0];",
 									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"",
 									"        tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"        tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"        tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"        tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"        tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"        tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"        tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"        tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"        tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"        tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1347,7 +1325,8 @@
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1367,10 +1346,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles?tag=dragons",
 							"host": [
@@ -1395,7 +1370,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "0408ab3b-8fba-4600-b4d1-8a34c0552aba",
 								"exec": [
 									"if (!(environment.isIntegrationTest)) {",
 									"var responseJSON = JSON.parse(responseBody);",
@@ -1403,14 +1378,15 @@
 									"tests['Response contains \"article\" property'] = responseJSON.hasOwnProperty('article');",
 									"",
 									"var article = responseJSON.article || {};",
+									"var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1420,7 +1396,8 @@
 									"tests['favoritesCount is an integer'] = Number.isInteger(article.favoritesCount);",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1463,21 +1440,22 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "af51c8ea-5732-4ffe-a28c-82cd742090b2",
 								"exec": [
 									"var responseJSON = JSON.parse(responseBody);",
 									"",
 									"tests['Response contains \"article\" property'] = responseJSON.hasOwnProperty('article');",
 									"",
 									"var article = responseJSON.article || {};",
+									"var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1488,7 +1466,8 @@
 									"tests['favoritesCount is an integer'] = Number.isInteger(article.favoritesCount);",
 									"tests[\"Article's 'favoritesCount' property is greater than 0\"] = article.favoritesCount > 0;",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1532,21 +1511,22 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "453dada6-0f2b-4be5-af76-3439b5616cdb",
 								"exec": [
 									"var responseJSON = JSON.parse(responseBody);",
 									"",
 									"tests['Response contains \"article\" property'] = responseJSON.hasOwnProperty('article');",
 									"",
 									"var article = responseJSON.article || {};",
+									"var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"tests['Article has \"title\" property'] = article.hasOwnProperty('title');",
 									"tests['Article has \"slug\" property'] = article.hasOwnProperty('slug');",
 									"tests['Article has \"body\" property'] = article.hasOwnProperty('body');",
 									"tests['Article has \"createdAt\" property'] = article.hasOwnProperty('createdAt');",
-									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.createdAt);",
+									"tests['Article\\'s \"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.createdAt);",
 									"tests['Article has \"updatedAt\" property'] = article.hasOwnProperty('updatedAt');",
-									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(article.updatedAt);",
+									"tests['Article\\'s \"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(article.updatedAt);",
 									"tests['Article has \"description\" property'] = article.hasOwnProperty('description');",
 									"tests['Article has \"tagList\" property'] = article.hasOwnProperty('tagList');",
 									"tests['Article\\'s \"tagList\" property is an Array'] = Array.isArray(article.tagList);",
@@ -1556,7 +1536,8 @@
 									"tests['favoritesCount is an integer'] = Number.isInteger(article.favoritesCount);",
 									"tests[\"Article's \\\"favorited\\\" property is false\"] = article.favorited === false;",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1601,25 +1582,26 @@
 							"listen": "test",
 							"script": {
 								"id": "9f90c364-cc68-4728-961a-85eb00197d7b",
-								"type": "text/javascript",
 								"exec": [
 									"var responseJSON = JSON.parse(responseBody);",
 									"",
 									"tests['Response contains \"comment\" property'] = responseJSON.hasOwnProperty('comment');",
 									"",
 									"var comment = responseJSON.comment || {};",
+									"var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
 									"",
 									"tests['Comment has \"id\" property'] = comment.hasOwnProperty('id');",
 									"pm.globals.set('commentId', comment.id);",
 									"",
 									"tests['Comment has \"body\" property'] = comment.hasOwnProperty('body');",
 									"tests['Comment has \"createdAt\" property'] = comment.hasOwnProperty('createdAt');",
-									"tests['\"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(comment.createdAt);",
+									"tests['\"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(comment.createdAt);",
 									"tests['Comment has \"updatedAt\" property'] = comment.hasOwnProperty('updatedAt');",
-									"tests['\"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(comment.updatedAt);",
+									"tests['\"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(comment.updatedAt);",
 									"tests['Comment has \"author\" property'] = comment.hasOwnProperty('author');",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1663,7 +1645,7 @@
 						{
 							"listen": "test",
 							"script": {
-								"type": "text/javascript",
+								"id": "21b1f643-bbf9-41e3-80e7-9e0c34139117",
 								"exec": [
 									"var is200Response = responseCode.code === 200",
 									"",
@@ -1676,18 +1658,20 @@
 									"",
 									"    if(responseJSON.comments.length){",
 									"        var comment = responseJSON.comments[0];",
-									"",
+									"        var is_iso8601 = (s => RegExp(pm.globals.get(\"iso8601_pattern\")).test(s));",
+									"        ",
 									"        tests['Comment has \"id\" property'] = comment.hasOwnProperty('id');",
 									"        tests['Comment has \"body\" property'] = comment.hasOwnProperty('body');",
 									"        tests['Comment has \"createdAt\" property'] = comment.hasOwnProperty('createdAt');",
-									"        tests['\"createdAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(comment.createdAt);",
+									"        tests['\"createdAt\" property is an ISO 8601 timestamp'] = is_iso8601(comment.createdAt);",
 									"        tests['Comment has \"updatedAt\" property'] = comment.hasOwnProperty('updatedAt');",
-									"        tests['\"updatedAt\" property is an ISO 8601 timestamp'] = /^\\d{4,}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d.\\d+(?:[+-][0-2]\\d:[0-5]\\d|Z)$/.test(comment.updatedAt);",
+									"        tests['\"updatedAt\" property is an ISO 8601 timestamp'] = is_iso8601(comment.updatedAt);",
 									"        tests['Comment has \"author\" property'] = comment.hasOwnProperty('author');",
 									"    }",
 									"}",
 									""
-								]
+								],
+								"type": "text/javascript"
 							}
 						}
 					],
@@ -1707,10 +1691,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/articles/{{slug}}/comments",
 							"host": [
@@ -1819,7 +1799,8 @@
 						]
 					}
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Profiles",
@@ -1925,10 +1906,6 @@
 								"value": "Token {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/profiles/celeb_{{USERNAME}}",
 							"host": [
@@ -2074,7 +2051,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Tags",
@@ -2114,10 +2092,6 @@
 								"value": "XMLHttpRequest"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "{{APIURL}}/tags",
 							"host": [
@@ -2130,7 +2104,39 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		}
-	]
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "38576f7c-62e0-439e-aab7-faa2a09e0836",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "bb75ff1b-fe47-41cf-85f7-6880adc427c5",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"id": "c1c5d112-5690-40b3-873f-1bacef27cbbb",
+			"key": "iso8601_pattern",
+			"value": "^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-](?:2[0-3]|[01][0-9]):[0-5][0-9])?$",
+			"type": "string"
+		}
+	],
+	"protocolProfileBehavior": {}
 }


### PR DESCRIPTION
The regex used to perform timestamp validation fails to parse valid
timestamps that do not have fractional seconds (e.g. `2020-04-14T19:54:46Z`).

This change (1) updates the regex to account for this and (2) moves the regex
into a global variable so it lives in one place.

The new regex is sourced from Ch 4.7 in `Regular Expressions Cookbook` 2e
by Goyvaerts and Levithan.

note - From what I can tell Postman only allows strings in environment
variables so I cannot simply put the validation function there.
