### PR TITLE
Remove Ember Octane

### DIFF
--- a/etc/frontend-repos.yaml
+++ b/etc/frontend-repos.yaml
@@ -85,9 +85,6 @@
 - title: Next.js
   repo:  reck1ess/next-realworld-example-app
   logo:  https://raw.githubusercontent.com/reck1ess/next-realworld-example-app/master/project-logo.png
-- title: Ember Octane
-  repo:  patocallaghan/ember-octane-realworld
-  logo:  https://raw.githubusercontent.com/patocallaghan/ember-octane-realworld/master/logo.png
 - title: neo.mjs
   repo:  neomjs/neomjs-realworld-example-app
   logo:  https://raw.githubusercontent.com/gothinkster/realworld-starter-kit/master/logo.png


### PR DESCRIPTION
After discussions in the Ember community we've decided to merge the "Ember Octane Realworld" app into the regular [Ember Realworld app](https://github.com/gothinkster/ember-realworld) so there is no longer a need for both anymore.