### PR TITLE
Fix typo (change 'distirbution' to 'distribution')

### DIFF
--- a/spec/mobile_icons/ios/README.md
+++ b/spec/mobile_icons/ios/README.md
@@ -7,7 +7,7 @@ the '.png' extension is actually required for iTunesConnect submission.
 
 This is done for you so you don't have to.
 
-However, for Ad_hoc or Enterprise distirbution, the extension should be removed
+However, for Ad_hoc or Enterprise distribution, the extension should be removed
 from the files before adding to XCode to avoid error.
 
 refs: https://developer.apple.com/library/ios/qa/qa1686/_index.html


### PR DESCRIPTION
For reference: https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines