### PR TITLE
Fix Purescript + Halogen frontend logo url

### DIFF
--- a/etc/frontend-repos.yaml
+++ b/etc/frontend-repos.yaml
@@ -45,7 +45,7 @@
   logo:  https://raw.githubusercontent.com/kwasniew/hyperapp-realworld-example-app/master/logo.png
 - title: PureScript + Halogen
   repo:  thomashoneyman/purescript-halogen-realworld
-  logo:  https://raw.githubusercontent.com/thomashoneyman/purescript-halogen-realworld/master/assets/logo.png
+  logo:  https://raw.githubusercontent.com/thomashoneyman/purescript-halogen-realworld/main/assets/logo.png
 - title: Imba
   repo:  cartonalexandre/imba-realworld-example-app
   logo:  https://raw.githubusercontent.com/cartonalexandre/imba-realworld-example-app/master/logo.png


### PR DESCRIPTION
The url is obsolete because master branch has been renamed to main some time ago