### PR TITLE
Add Layr/React fullstack implementation

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -41,7 +41,10 @@ Work In Progress:
 
 _Since these implementations are responsible for the entire stack, they obviously cannot be mixed and matched but they still adhere to the same functionality & UX specs._
 
-Work In Progress: **[Meteor]() | [Ruby Hyperloop]() | [Firebase](https://github.com/gothinkster/realworld/issues/199)**
+<!-- INSERT_FULLSTACK_REPOS -->
+
+Work In Progress:
+<!-- INSERT_FULLSTACK_WIP -->
 
 # Create a new stack
 

--- a/etc/fullstack-repos.yaml
+++ b/etc/fullstack-repos.yaml
@@ -1,0 +1,3 @@
+- title: Liaison / React
+  repo:  liaisonjs/react-liaison-realworld-example-app
+  logo:  https://raw.githubusercontent.com/liaisonjs/react-liaison-realworld-example-app/master/assets/logo.png

--- a/etc/fullstack-repos.yaml
+++ b/etc/fullstack-repos.yaml
@@ -1,3 +1,3 @@
-- title: Liaison / React
-  repo:  liaisonjs/react-liaison-realworld-example-app
-  logo:  https://raw.githubusercontent.com/liaisonjs/react-liaison-realworld-example-app/master/assets/logo.png
+- title: Layr / React
+  repo:  layrjs/react-layr-realworld-example-app
+  logo:  https://raw.githubusercontent.com/layrjs/react-layr-realworld-example-app/master/assets/logo.png

--- a/etc/update-readme.js
+++ b/etc/update-readme.js
@@ -16,14 +16,17 @@ const README_TARGET_FILE = '../README.md';
 const FRONTEND_PLACEHOLDER = 'INSERT_FRONTEND_REPOS';
 const BACKEND_PLACEHOLDER = 'INSERT_BACKEND_REPOS';
 const MOBILE_PLACEHOLDER = 'INSERT_MOBILE_REPOS';
+const FULLSTACK_PLACEHOLDER = 'INSERT_FULLSTACK_REPOS';
 
 const FRONTEND_WIP_PLACEHOLDER = 'INSERT_FRONTEND_WIP';
 const BACKEND_WIP_PLACEHOLDER = 'INSERT_BACKEND_WIP';
 const MOBILE_WIP_PLACEHOLDER = 'INSERT_MOBILE_WIP';
+const FULLSTACK_WIP_PLACEHOLDER = 'INSERT_FULLSTACK_WIP';
 
 const FRONTEND_REPOS = jsYaml.safeLoad(fs.readFileSync('frontend-repos.yaml', 'utf8'));
 const BACKEND_REPOS = jsYaml.safeLoad(fs.readFileSync('backend-repos.yaml', 'utf8'));
 const MOBILE_REPOS = jsYaml.safeLoad(fs.readFileSync('mobile-repos.yaml', 'utf8'));
+const FULLSTACK_REPOS = jsYaml.safeLoad(fs.readFileSync('fullstack-repos.yaml', 'utf8'));
 
 (async () => {
   await main();
@@ -46,12 +49,16 @@ async function main() {
       output.push(...(await getSortedTable(BACKEND_REPOS)));
     } else if (input[i].includes(MOBILE_PLACEHOLDER)) {
       output.push(...(await getSortedTable(MOBILE_REPOS)));
+    } else if (input[i].includes(FULLSTACK_PLACEHOLDER)) {
+      output.push(...(await getSortedTable(FULLSTACK_REPOS)));
     } else if (input[i].includes(FRONTEND_WIP_PLACEHOLDER)) {
       output.push(await getWIPProjects('frontend'));
     } else if (input[i].includes(BACKEND_WIP_PLACEHOLDER)) {
       output.push(await getWIPProjects('backend'));
     } else if (input[i].includes(MOBILE_WIP_PLACEHOLDER)) {
       output.push(await getWIPProjects('mobile'));
+    } else if (input[i].includes(FULLSTACK_WIP_PLACEHOLDER)) {
+      output.push(await getWIPProjects('fullstack'));
     } else {
       output.push(input[i]);
     }


### PR DESCRIPTION
- Created `etc/fullstack-repos.yaml` to add the [Layr/React](https://github.com/layrjs/react-layr-realworld-example-app) fullstack implementation.
- Modified `README.template.md` and `etc/update-readme.js` to auto-generate the fullstack section of `README.md` according to the content of `etc/fullstack-repos.yaml`.