### PR TITLE
fix(update-readme): Do not fail if repo absent

### DIFF
--- a/etc/backend-repos.yaml
+++ b/etc/backend-repos.yaml
@@ -37,9 +37,6 @@
 - title: Go + Gin
   repo:  gothinkster/golang-gin-realworld-example-app
   logo:  https://github.com/gothinkster/golang-gin-realworld-example-app/blob/master/logo.png
-- title: Rust
-  repo:  gothinkster/rust-realworld-example-app
-  logo:  https://github.com/gothinkster/rust-realworld-example-app/raw/master/logo.png
 - title: GCP Cloud Functions + Datastore
   repo:  gothinkster/gcp-datastore-cloud-functions-realworld-example-app
   logo:  https://github.com/gothinkster/gcp-datastore-cloud-functions-realworld-example-app/raw/master/logo.png

--- a/etc/update-readme.js
+++ b/etc/update-readme.js
@@ -65,10 +65,15 @@ async function getSortedTable(repos) {
 
   // Get sorted repos by stargazers_count
   for (let i = 0; i < repos.length; ++i) {
-    const stargazers_count =
-      (await axios.get(`/repos/${repos[i].repo}`))
-      .data.stargazers_count;
-    repos[i].stargazers_count = stargazers_count;
+    let repoData = null;
+    try {
+      repoData = await axios.get(`/repos/${repos[i].repo}`);
+    } catch(err) {
+      console.warn(`Error fetching data for: ${repos[i].repo}`);
+      repos[i].stargazers_count = -1;
+      continue;
+    }
+    repos[i].stargazers_count = repoData.data.stargazers_count;
   }
   repos = repos.sort((a, b) => b.stargazers_count - a.stargazers_count);
   console.log('\n\nSorted repos: \n\n' + repos.map(e => `  ${e.repo} (${e.stargazers_count})`).join('\n') + '\n\n');


### PR DESCRIPTION
If a repo is absent, `etc/update-readme.js` fails. E.g see [this build](https://travis-ci.org/github/gothinkster/realworld/builds/750714410).

This fixes it.