### PR TITLE
fix swagger for how to register a new user

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -71,7 +71,7 @@
         }
       }
     },
-    "/user": {
+    "/users": {
       "post": {
         "summary": "Register a new user",
         "description": "Register a new user",
@@ -104,7 +104,9 @@
             }
           }
         }
-      },
+      }
+    }
+    "/user": {
       "get": {
         "summary": "Get current user",
         "description": "Gets the currently logged-in user",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -105,7 +105,7 @@
           }
         }
       }
-    }
+    },
     "/user": {
       "get": {
         "summary": "Get current user",


### PR DESCRIPTION
To register a new user POST to `/users` not to `/user`.