### PR TITLE
Forward arguments from run-api-tests.sh to newman

### DIFF
--- a/api/run-api-tests.sh
+++ b/api/run-api-tests.sh
@@ -13,4 +13,5 @@ npx newman run $SCRIPTDIR/Conduit.postman_collection.json \
   --global-var "APIURL=$APIURL" \
   --global-var "USERNAME=$USERNAME" \
   --global-var "EMAIL=$EMAIL" \
-  --global-var "PASSWORD=$PASSWORD"
+  --global-var "PASSWORD=$PASSWORD" \
+  "$@"


### PR DESCRIPTION
This allows running e.g. ./run-api-tests.sh --folder Register
to isolate just one specific test.