### PR TITLE
Update swagger.json

### DIFF
--- a/api/swagger.json
+++ b/api/swagger.json
@@ -71,7 +71,7 @@
         }
       }
     },
-    "/user": {
+    "/users": {
       "post": {
         "summary": "Register a new user",
         "description": "Register a new user",
@@ -104,7 +104,9 @@
             }
           }
         }
-      },
+      }
+    },
+    "/user": {
       "get": {
         "summary": "Get current user",
         "description": "Gets the currently logged-in user",


### PR DESCRIPTION
Seems it's a known issue: #380

Current swagger file doesn't match description in README.md file in `api` and `Conduit.postman_collection.json`.

The registration should be located at `/api/users` but it's at `/api/user` at the moment.

This fix moves registration into a new path section `/users`.