### PR TITLE
feat(project): update to newman 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "devDependencies": {
     "axios": "^0.18.0",
     "js-yaml": "^3.11.0",
-    "newman": "^3.5.2"
+    "newman": "^5.2.3"
   }
 }


### PR DESCRIPTION
Previously we had newman": "^3.5.2", but if you install exactly 3.5.2
e.g. with npm install newman@3.5.2 the ./api/run-api-tests.sh fails with:

Unrecognized arguments: --global-var

because that feature was added after 3.5. It works with npm install
because if fetches the newer version currently 3.10 which has it.

Since I was upgrading this, I though I might as well update to 5 as it just
works.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/gothinkster/realworld/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
