### PR TITLE
refactor(openapi): remove default description for filtering

### DIFF
--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -232,13 +232,13 @@ paths:
       parameters:
         - name: limit
           in: query
-          description: Limit number of articles returned (default is 20)
+          description: Limit number of articles returned
           schema:
             type: integer
             default: 20
         - name: offset
           in: query
-          description: Offset/skip number of articles (default is 0)
+          description: Offset/skip number of articles
           schema:
             type: integer
             default: 0
@@ -286,13 +286,13 @@ paths:
             type: string
         - name: limit
           in: query
-          description: Limit number of articles returned (default is 20)
+          description: Limit number of articles returned
           schema:
             type: integer
             default: 20
         - name: offset
           in: query
-          description: Offset/skip number of articles (default is 0)
+          description: Offset/skip number of articles
           schema:
             type: integer
             default: 0


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/gothinkster/realworld/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Other... Please describe: Documentation


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The default value for filtering is explicitly part of the description while already included as part of the API documentation itself

Issue Number: N/A


## What is the new behavior?
The `default is xx` mentions are remoed


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
