### PR TITLE
feat: change API documentation link to bump.sh

### DIFF
--- a/documentation/docs/specs/frontend-specs/api.md
+++ b/documentation/docs/specs/frontend-specs/api.md
@@ -49,9 +49,9 @@ If the hosted API receives no traffic in 30 minutes, it will sleep. In such a si
 
 Non-demo Articles, Tags, and Comments are deleted on a daily basis to avoid additional costs.
 
-### Swagger documentation
+### OpenAPI documentation
 
-The API exposes a **Swagger** documentation on `https://api.realworld.io/api-docs`.
+The API exposes a **OpenAPI** documentation on `hhttps://bump.sh/doc/realworld`.
 
 Most of the requests require a valid token.
 

--- a/documentation/docs/specs/mobile-specs/introduction.md
+++ b/documentation/docs/specs/mobile-specs/introduction.md
@@ -9,7 +9,7 @@ sidebar_position: 1
 ### Using the hosted API
 
 API URL : https://api.realworld.io/api    
-SWAGGER : https://api.realworld.io/api-docs
+OpenAPI : https://bump.sh/doc/realworld
 
 
 ### Styles/Templates


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/gothinkster/realworld/blob/master/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The current API documentation link is `https://api.realworld.io/api-docs`.

Issue Number: N/A


## What is the new behavior?
The new API documentation link for v2 is `https://bump.sh/doc/realworld`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
