### PR TITLE
feat(storybook): add usage custom tab

### DIFF
--- a/apps/demo/.storybook/manager.js
+++ b/apps/demo/.storybook/manager.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { addons, types } from '@storybook/manager-api';
+
+addons.register('usage', () => {
+  addons.add('realworld/usage', {
+    type: types.TAB,
+    title: 'Usage',
+    //👇 Checks the current route for the story
+    route: ({ storyId, refId }) => (refId ? `/usage/${refId}_${storyId}` : `/usage/${storyId}`),
+    //👇 Shows the Tab UI element in mytab view mode
+    match: ({ viewMode }) => viewMode === 'usage',
+    render: () => (
+      <div>
+        <h2>I'm a tabbed addon in Storybook</h2>
+      </div>
+    ),
+  });
+});

--- a/apps/demo/.storybook/preview.js
+++ b/apps/demo/.storybook/preview.js
@@ -17,4 +17,15 @@ export const parameters = {
       },
     ],
   },
+  previewTabs: {
+    'storybook/story/panel': {
+      hidden: true,
+    },
+    'storybook/canvas/panel': {
+      hidden: true,
+    },
+    'realworld/usage/panel': {
+      hidden: false,
+    },
+  },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
         "@storybook/blocks": "^7.0.0-beta.59",
         "@storybook/core-server": "7.0.0-beta.59",
         "@storybook/jest": "^0.0.11-next.0",
+        "@storybook/manager-api": "^7.0.0-beta.54",
         "@storybook/preview-api": "^7.0.0-beta.59",
         "@storybook/react": "7.0.0-beta.59",
         "@storybook/react-vite": "^7.0.0-beta.59",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@storybook/core-server": "7.0.0-beta.59",
     "@storybook/jest": "^0.0.11-next.0",
     "@storybook/preview-api": "^7.0.0-beta.59",
+    "@storybook/manager-api": "^7.0.0-beta.54",
     "@storybook/react": "7.0.0-beta.59",
     "@storybook/react-vite": "^7.0.0-beta.59",
     "@storybook/testing-library": "^0.0.14-next.1",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/gothinkster/realworld/blob/master/CONTRIBUTING.md#commit

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Other... Please describe:

## What is the current behavior?
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe9c7d5</samp>

This pull request adds a custom usage panel to the Storybook UI for the demo app, using the `@storybook/manager-api` package. The panel shows how the components can be used in real-world scenarios, and replaces the default story and canvas tabs.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe9c7d5</samp>

* Create a custom tabbed addon for the Storybook manager UI to show usage panels for each story ([link](https://github.com/gothinkster/realworld/pull/1164/files?diff=unified&w=0#diff-956ec371cea4d7d0210180e1557f4c4445b0ffff9948334db9f0b92656ccb674R1-R19), [link](https://github.com/gothinkster/realworld/pull/1164/files?diff=unified&w=0#diff-73e402524f62f2873d373d16c6bd355f4839a5247c168210236dd80c52eabb4cR20-R30), [link](https://github.com/gothinkster/realworld/pull/1164/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R73))
  - Add the `@storybook/manager-api` package as a dependency in `package.json` ([link](https://github.com/gothinkster/realworld/pull/1164/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R73))
  - Use the package to register a custom addon in `apps/demo/.storybook/manager.js` ([link](https://github.com/gothinkster/realworld/pull/1164/files?diff=unified&w=0#diff-956ec371cea4d7d0210180e1557f4c4445b0ffff9948334db9f0b92656ccb674R1-R19))
  - Hide the default story and canvas tabs and show the custom usage tab instead in `apps/demo/.storybook/preview.js` ([link](https://github.com/gothinkster/realworld/pull/1164/files?diff=unified&w=0#diff-73e402524f62f2873d373d16c6bd355f4839a5247c168210236dd80c52eabb4cR20-R30))

Add a custom tab for Storybook

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
