### PR TITLE
chore: use npm caching for api workflow

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -19,10 +19,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
+        id: setup-node
         with:
           node-version: '16'
-          cache: 'npm'
+
+      - name: Get node version
+        id: node
+        run: |
+          echo "::set-output name=version::$(node -v)"
+
+      - name: Get node_modules cache
+        uses: actions/cache@v3.3.1
+        id: node_modules
+        with:
+          path: |
+            **/node_modules
+          # Adding node version as cache key
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ steps.node.outputs.version }}
+
       - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: npm ci --no-audit --prefer-offline --progress=false
       - name: Check prettier
         run: npm run prettier:check


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 69b8544</samp>

Use `actions/cache` to cache `node_modules` in GitHub workflow. This can speed up and stabilize the `api.yaml` workflow by avoiding unnecessary `npm ci` calls.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 69b8544</samp>

* Cache `node_modules` folders across workflow runs to improve performance and reliability ([link](https://github.com/gothinkster/realworld/pull/1201/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8L22-R39))
* Use `id` and `outputs` properties to get node version from `setup-node` and `node` steps ([link](https://github.com/gothinkster/realworld/pull/1201/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8L22-R39))
