### PR TITLE
fix: npm caching reference

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -29,8 +29,8 @@ jobs:
           echo "::set-output name=version::$(node -v)"
 
       - name: Get node_modules cache
-        uses: actions/cache@v3.3.1
-        id: node_modules
+        uses: actions/cache@v3
+        id: cache
         with:
           path: |
             **/node_modules


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4af09e3</samp>

Simplify the caching step of the API tests workflow by using the latest `actions/cache` action and a shorter `id`. This improves the readability and maintainability of the `.github/workflows/api.yaml` file.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4af09e3</samp>

*  Simplify the caching of node_modules for the API tests by using the latest version of `actions/cache` and shorter identifiers ([link](https://github.com/gothinkster/realworld/pull/1202/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8L32-R33),   ) in `.github/workflows/api.yaml`
