### PR TITLE
chore: organize CI jobs

### DIFF
--- a/.github/workflows/api-testing-playwright.yaml
+++ b/.github/workflows/api-testing-playwright.yaml
@@ -2,38 +2,15 @@ name: API Testing Playwright
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-  pull_request:
-    branches:
-      - '**'
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
 
 jobs:
   run_tests:
     runs-on: ubuntu-latest
+    uses: gothinkster/realworld/.github/workflows/node-setup.yaml@main
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        id: setup-node
-        with:
-          node-version: '16'
-
-      - name: Get node version
-        id: node
-        run: |
-          echo "::set-output name=version::$(node -v)"
-
-      - name: Get node_modules cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            **/node_modules
-          # Adding node version as cache key
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ steps.node.outputs.version }}
-
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci --no-audit --prefer-offline --progress=false
       - name: run tests
         run: npx nx e2e api-testing-playwright

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -9,42 +9,18 @@ on:
       - '**'
 
 jobs:
-  run_tests:
+  linting:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
-        id: setup-node
-        with:
-          node-version: '16'
-
-      - name: Get node version
-        id: node
-        run: |
-          echo "::set-output name=version::$(node -v)"
-
-      - name: Get node_modules cache
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: |
-            **/node_modules
-          # Adding node version as cache key
-          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ steps.node.outputs.version }}
-
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: npm ci --no-audit --prefer-offline --progress=false
+      - uses: gothinkster/realworld/.github/workflows/node-setup.yaml@main
       - name: Check prettier
         run: npm run prettier:check
       - name: Check ESLinter
         run: npm run lint:check
+  unit_testing:
+    runs-on: ubuntu-latest
+    needs: linting
+    steps:
+      - uses: gothinkster/realworld/.github/workflows/node-setup.yaml@main
       - name: Check unit tests
         run: npm run test --ci --lastCommit --maxWorkers=50%
-        env:
-          CI: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,15 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-          cache: 'npm'
-      - name: Install dependencies
-        run: npm ci --no-audit --prefer-offline --progress=false
+      - uses: gothinkster/realworld/.github/workflows/node-setup.yaml@main
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,10 +2,10 @@ name: 'CodeQL'
 
 on:
   workflow_dispatch:
-  push:
-    branches: ['main']
-  pull_request:
-    branches: ['main']
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
   schedule:
     - cron: '24 3 * * 3'
 

--- a/.github/workflows/node-setup.yaml
+++ b/.github/workflows/node-setup.yaml
@@ -1,0 +1,31 @@
+name: Setup node
+
+on: workflow_call
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        id: setup-node
+        with:
+          node-version: '16'
+
+      - name: Get node version
+        id: node
+        run: |
+          echo "::set-output name=version::$(node -v)"
+
+      - name: Get node_modules cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            **/node_modules
+          # Adding node version as cache key
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ steps.node.outputs.version }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --no-audit --prefer-offline --progress=false


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd5bc38</samp>

This pull request improves the GitHub Actions workflows for the RealWorld API by making them more efficient, modular, and reusable. It introduces a new reusable workflow for node setup, splits the CI workflow into linting and testing jobs, and runs the Playwright and CodeQL workflows only after the CI workflow passes.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fd5bc38</samp>

*  Run end-to-end tests with Playwright only after CI workflow succeeds ([link](https://github.com/gothinkster/realworld/pull/1204/files?diff=unified&w=0#diff-8ef289f9e4b279816ed3af21857b5ac8eb62bc22fb2e46f88fb6235fe120f38bL5-R8))
*  Use reusable workflow for node setup in Playwright and CI workflows ([link](https://github.com/gothinkster/realworld/pull/1204/files?diff=unified&w=0#diff-8ef289f9e4b279816ed3af21857b5ac8eb62bc22fb2e46f88fb6235fe120f38bL15-R14), [link](https://github.com/gothinkster/realworld/pull/1204/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8L12-R26))
*  Split linting and unit testing into separate jobs in `api.yaml` ([link](https://github.com/gothinkster/realworld/pull/1204/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8L12-R26))
*  Run CodeQL analysis only after CI workflow succeeds ([link](https://github.com/gothinkster/realworld/pull/1204/files?diff=unified&w=0#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L5-R8))
*  Extract node setup code into reusable workflow in `node-setup.yaml` ([link](https://github.com/gothinkster/realworld/pull/1204/files?diff=unified&w=0#diff-d9364e2787ab93c6f961fe3544003f441184ea8aab62e13d77dbc77ed0b24f12R1-R31))
