### PR TITLE
fix: chromatic depth versioning

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -158,6 +158,8 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v3
         id: setup-node
         with:


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 35c2806</samp>

Set `fetch-depth` to 0 for `actions/checkout@v2` in `.github/workflows/api.yaml` to enable correct coverage reporting by `coverallsapp/github-action@v1.1.2`.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 35c2806</samp>

* Fetch the entire git history for the coverage report ([link](https://github.com/gothinkster/realworld/pull/1207/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8R161-R162))
