### PR TITLE
feat(api-testing-cypress): add ci testing

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -94,7 +94,22 @@ jobs:
         run: npm ci --no-audit --prefer-offline --progress=false
       - name: Check unit tests
         run: npm run test --ci --lastCommit --maxWorkers=50%
-  api_testing:
+  api_testing_cypress:
+    name: API Testing (Cypress)
+    runs-on: ubuntu-latest
+    needs: [linting, codeql]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        id: setup-node
+        with:
+          node-version: '16'
+      - name: Install dependencies
+        run: npm ci --no-audit --prefer-offline --progress=false
+      - name: Check api tests
+        run: npx nx e2e api-testing-cypress
+  api_testing_playwright:
+    name: API Testing (Playwright)
     runs-on: ubuntu-latest
     needs: [linting, codeql]
     steps:


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0d53e7a</samp>

Updated the GitHub workflow for API testing to include Playwright as an alternative framework. The workflow now runs two jobs, `api_testing_cypress` and `api_testing_playwright`, on the same file `.github/workflows/api.yaml`.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0d53e7a</samp>

* Rename and add jobs for testing API endpoints with different frameworks ([link](https://github.com/gothinkster/realworld/pull/1212/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8L97-R98), [link](https://github.com/gothinkster/realworld/pull/1212/files?diff=unified&w=0#diff-61bbd9dcf747db245cfe2cc1fe090fe3dc738092b8c9ad6749ba6fdfb34486b8R126-R155))
