### PR TITLE
chore: add githubnext codebase diagram action

### DIFF
--- a/.github/workflows/codebase-diagram.yml
+++ b/.github/workflows/codebase-diagram.yml
@@ -1,0 +1,16 @@
+name: Create codebase diagram
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+jobs:
+  get_data:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Update diagram
+        uses: githubocto/repo-visualizer@main
+        with:
+          excluded_paths: 'ignore,.github'

--- a/CODEBASE_DIAGRAM.md
+++ b/CODEBASE_DIAGRAM.md
@@ -1,0 +1,3 @@
+# Codebase Diagram
+
+![Visualization of this repo](./diagram.svg)


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a9e54de</samp>

This pull request adds a feature to generate and display a codebase diagram of the repository using the `repo-visualizer` action. It creates a new workflow file `.github/workflows/codebase-diagram.yml` and a new markdown file `CODEBASE_DIAGRAM.md` to implement this feature.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a9e54de</samp>

* Add a GitHub workflow to generate a codebase diagram ([link](https://github.com/gothinkster/realworld/pull/1216/files?diff=unified&w=0#diff-1495d48d41c9ef647fd49f99a71f793d228038f033ca7278d4d2180f3717d806R1-R16))
* Create a markdown file to display the codebase diagram ([link](https://github.com/gothinkster/realworld/pull/1216/files?diff=unified&w=0#diff-69d3c460d9930138314dbd7296a9d079306bdc39d8527fcb93abaf550fceec54R1-R3))
