### PR TITLE
feat: add continuous deployment

### DIFF
--- a/.github/workflows/codebase-diagram.yml
+++ b/.github/workflows/codebase-diagram.yml
@@ -1,11 +1,8 @@
 name: Create codebase diagram
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ['CI']
+  push:
     branches: [main]
-    types:
-      - completed
 jobs:
   get_data:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -1,0 +1,56 @@
+name: Continuous deployment
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  api_documentation_bump:
+    name: Deploy API documentation (Bump)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Deploy API documentation
+        uses: bump-sh/github-action@v1
+        with:
+          doc: conduit
+          token: ${{secrets.BUMP_TOKEN}}
+          file: api/openapi.yml
+  deploy_live_demo:
+    name: Deploy Live (Demo)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        id: setup-node
+        with:
+          node-version: '16'
+
+      - name: Get node version
+        id: node
+        run: |
+          echo "::set-output name=version::$(node -v)"
+
+      - name: Get node_modules cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          path: |
+            **/node_modules
+          # Adding node version as cache key
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}-${{ steps.node.outputs.version }}
+
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci --no-audit --prefer-offline --progress=false
+      - run: npx nx build demo
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v2
+        with:
+          publish-dir: './dist/apps/demo'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          production-deploy: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.DEMO_NETLIFY_ID }}

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,9 +1,7 @@
-name: CI
+name: Continuous integration
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
   pull_request:
     branches:
       - '**'
@@ -262,18 +260,6 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           token: ${{ secrets.GITHUB_TOKEN }}
-  api_documentation:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [api_testing_cypress, api_testing_playwright]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Deploy API documentation
-        uses: bump-sh/github-action@v1
-        with:
-          doc: conduit
-          token: ${{secrets.BUMP_TOKEN}}
-          file: api/openapi.yml
   deploy_preview_demo:
     name: Deploy Preview (Demo)
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 856f093</samp>

This pull request refactors the GitHub workflows to separate the continuous integration and continuous deployment tasks. It also adds a new workflow to deploy the API documentation and the live demo app to `Bump` and `Netlify` on every push to the `main` branch.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 856f093</samp>

*  Simplify codebase diagram workflow trigger to run on push to main branch ([link](https://github.com/gothinkster/realworld/pull/1266/files?diff=unified&w=0#diff-1495d48d41c9ef647fd49f99a71f793d228038f033ca7278d4d2180f3717d806L4-R5))
*  Add continuous deployment workflow to automate API documentation and live demo app deployment to Bump and Netlify ([link](https://github.com/gothinkster/realworld/pull/1266/files?diff=unified&w=0#diff-d6e37d8db765e21cf58ba38c965d3b81e792b464d5bfe83e4314fbddd5c0a33dR1-R56))
*  Rename API workflow to continuous integration and update workflow name ([link](https://github.com/gothinkster/realworld/pull/1266/files?diff=unified&w=0#diff-208542bbdcc8946dccfcfd7b7ac20705e8c5f382cdb3bd7fe6ecea4e3b9cf04bL1-R1))
*  Remove API documentation job from continuous integration workflow ([link](https://github.com/gothinkster/realworld/pull/1266/files?diff=unified&w=0#diff-208542bbdcc8946dccfcfd7b7ac20705e8c5f382cdb3bd7fe6ecea4e3b9cf04bL265-L276))
