### PR TITLE
Update Realworld web stie link in swagger.json

### DIFF
--- a/apps/documentation/static/swagger.json
+++ b/apps/documentation/static/swagger.json
@@ -5,7 +5,7 @@
     "description": "Conduit API documentation",
     "contact": {
       "name": "RealWorld",
-      "url": "https://realworld.how"
+      "url": "https://demo.realworld.io/"
     },
     "license": {
       "name": "MIT License",


### PR DESCRIPTION
Realworld website url was broken. Updated the url to the new demo site i.e. https://demo.realworld.io/

<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ece42b6</samp>

Updated the contact url of the API documentation in `swagger.json` to reflect the current demo site. This improves the usability and accuracy of the documentation for the RealWorld project.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ece42b6</samp>

* Update the contact url of the API documentation to point to the demo site ([link](https://github.com/gothinkster/realworld/pull/1288/files?diff=unified&w=0#diff-198a61f6628abd84f5d5bf6e53868319ac861537f9b10d8bbb032ee5e7c7233bL8-R8))
