### PR TITLE
Fix link to github repo for 'Edit this page' link

### DIFF
--- a/apps/documentation/docusaurus.config.js
+++ b/apps/documentation/docusaurus.config.js
@@ -25,7 +25,7 @@ const config = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           // Remove this to remove the "edit this page" links.
-          editUrl: 'https://github.com/gothinkster/realworld/tree/main/docs/docs/',
+          editUrl: 'https://github.com/gothinkster/realworld/blob/main/apps/documentation/docs/',
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
At the bottom of the Introduction page, https://realworld-docs.netlify.app/docs/intro, the link to the github repo seems to be broken.

It is sending us to:

https://github.com/gothinkster/realworld/tree/main/docs/docs/docs/intro.mdx

I think it should be:

https://github.com/gothinkster/realworld/blob/main/apps/documentation/docs/intro.mdx

So, I have made a pull request here. I am not sure if this is the correct place for this change to be made.

I notice that there may be a similar problem a few lines below with the link to the blog on line 33, but I could not find the blog so I have not investigated further.

<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60415e0</samp>

Fixed the edit links for the documentation pages by updating the `editUrl` configuration in `docusaurus.config.js`. This improves the user experience and the contribution workflow for the documentation.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60415e0</samp>

* Fix the edit URL for documentation pages ([link](https://github.com/gothinkster/realworld/pull/1383/files?diff=unified&w=0#diff-055c148b3ef19d835a0fa9f1b6bd4836c1d59a9486ddfb7b7107d56c0025cb57L28-R28))
