### PR TITLE
fix: update useQuery types

### DIFF
--- a/apps/demo/src/app/pages/article/article.page.tsx
+++ b/apps/demo/src/app/pages/article/article.page.tsx
@@ -19,7 +19,7 @@ const articleQuery = (slug: string) => ({
 
 export const loader =
   (queryClient: QueryClient) =>
-  async (slug: string): Promise<{ data: Article }> => {
+  async (slug: string): Promise<Article> => {
     const query = articleQuery(slug);
 
     return await queryClient.ensureQueryData(query);
@@ -31,7 +31,7 @@ export default function ArticlePage() {
 
   const { data: article } = useQuery<Article>({
     ...articleQuery(slug),
-    initialData: initialData.data,
+    initialData: initialData,
   });
 
   return (

--- a/apps/demo/src/app/pages/profile/profile.page.tsx
+++ b/apps/demo/src/app/pages/profile/profile.page.tsx
@@ -30,7 +30,7 @@ const profileQuery = (username: string) => ({
 
 export const loader =
   (queryClient: QueryClient) =>
-  async (username: string): Promise<{ data: Author }> => {
+  async (username: string): Promise<Author> => {
     const query = profileQuery(username);
 
     return await queryClient.ensureQueryData(query);
@@ -43,7 +43,7 @@ export default function ProfilePage({ defaultTab }: Props) {
   const navigate = useNavigate();
   const { data: profile } = useQuery<Author>({
     ...profileQuery(username),
-    initialData: initialData.data,
+    initialData: initialData,
   });
 
   const [page, setPage] = useState(1);


### PR DESCRIPTION
fixes #1412

<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a1f607</samp>

Simplified the data structures and queries for the article and profile pages in the demo app, using the direct types of `Article` and `Author` instead of nested objects in `apps/demo/src/app/pages/article/article.page.tsx` and `apps/demo/src/app/pages/profile/profile.page.tsx`.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a1f607</samp>

*  Simplify `loader` functions for article and profile pages to return data directly instead of wrapping it in an object ([link](https://github.com/gothinkster/realworld/pull/1413/files?diff=unified&w=0#diff-02653937ab312a6703e2fd4422b64b2e2ee5d4bc9d8e0eb2f1b312661acc0346L22-R22), [link](https://github.com/gothinkster/realworld/pull/1413/files?diff=unified&w=0#diff-2412ca19c46d8cf686fe9e8c6d60f1c564fa2a08993a004c3787284bff8ee15fL33-R33))
*  Update `useQuery` hooks for article and profile pages to use `initialData` directly instead of accessing its `data` property ([link](https://github.com/gothinkster/realworld/pull/1413/files?diff=unified&w=0#diff-02653937ab312a6703e2fd4422b64b2e2ee5d4bc9d8e0eb2f1b312661acc0346L34-R34), [link](https://github.com/gothinkster/realworld/pull/1413/files?diff=unified&w=0#diff-2412ca19c46d8cf686fe9e8c6d60f1c564fa2a08993a004c3787284bff8ee15fL46-R46))
