### PR TITLE
feat(api-testing-cypress): add more tests

### DIFF
--- a/apps/api-testing-cypress/src/e2e/article.cy.ts
+++ b/apps/api-testing-cypress/src/e2e/article.cy.ts
@@ -13,7 +13,32 @@ describe('@GET articles', () => {
 });
 
 describe('@GET feed', () => {
-  // TODO
+  it('OK @200', () => {
+    // When
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user.token).as('token');
+    });
+
+    cy.then(function () {
+      cy.getRequest(`/api/articles/feed`, this.token).then((response: Cypress.Response<any>) => {
+        // Then
+        expect(response.status).to.equal(200);
+        expect(response.body.articles.length).to.equal(0);
+        expect(response.body.articlesCount).to.equal(0);
+      });
+    });
+  });
+
+  it('KO @401', () => {
+    // When
+    cy.then(function () {
+      cy.getRequest(`/api/articles/feed`, undefined).then((response: Cypress.Response<any>) => {
+        // Then
+        expect(response.status).to.equal(401);
+        expect(response.body.message).to.equal('missing authorization credentials');
+      });
+    });
+  });
 });
 
 describe('@GET article', () => {
@@ -240,6 +265,12 @@ describe('@PUT article', () => {
         expect(response.status).to.equal(200);
         expect(response.body.article.description).to.equal('foo');
       });
+
+      cy.getRequest(`/api/articles/${this.slug}`).then((response: Cypress.Response<Article>) => {
+        // Then
+        expect(response.status).to.equal(200);
+        expect(response.body.article.description).to.equal('foo');
+      });
     });
   });
 
@@ -304,6 +335,11 @@ describe('@DELETE article', () => {
       deleteArticle(this.slug, this.token).then((response: Cypress.Response<never>) => {
         // Then
         expect(response.status).to.equal(204);
+      });
+
+      cy.getRequest(`/api/articles/${this.slug}`).then((response: Cypress.Response<never>) => {
+        // Then
+        expect(response.status).to.equal(404);
       });
     });
   });
@@ -432,6 +468,45 @@ describe('@POST favorite article', () => {
         expect(response.body.article.favorited).to.equal(true);
         expect(response.body.article.favoritesCount).to.equal(1);
       });
+
+      cy.getRequest(`/api/articles/${this.slug}`, this.followerToken).then(
+        (response: Cypress.Response<Article>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.article.favorited).to.equal(true);
+          expect(response.body.article.favoritesCount).to.equal(1);
+        },
+      );
+    });
+  });
+
+  it('KO @401', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user.token).as('token');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    // When
+    cy.then(function () {
+      favoriteArticle(this.slug, undefined).then((response: Cypress.Response<any>) => {
+        // Then
+        expect(response.status).to.equal(401);
+        expect(response.body.message).to.equal('missing authorization credentials');
+      });
     });
   });
 });
@@ -483,6 +558,364 @@ describe('@DELETE unfavorite article', () => {
           expect(response.status).to.equal(200);
           expect(response.body.article.favorited).to.equal(false);
           expect(response.body.article.favoritesCount).to.equal(0);
+        },
+      );
+
+      cy.getRequest(`/api/articles/${this.slug}`, this.followerToken).then(
+        (response: Cypress.Response<Article>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.article.favorited).to.equal(false);
+          expect(response.body.article.favoritesCount).to.equal(0);
+        },
+      );
+    });
+  });
+
+  it('KO @401', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user.token).as('token');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    // When
+    cy.then(function () {
+      unfavoriteArticle(this.slug, undefined).then((response: Cypress.Response<any>) => {
+        // Then
+        expect(response.status).to.equal(401);
+        expect(response.body.message).to.equal('missing authorization credentials');
+      });
+    });
+  });
+});
+
+describe('@GET comments', () => {
+  it('OK @200', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user.token).as('token');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    // When
+    cy.then(function () {
+      cy.getRequest(`/api/articles/${this.slug}/comments`, this.token).then(
+        (response: Cypress.Response<{ comments: Comment[] }>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.comments.length).to.equal(0);
+        },
+      );
+    });
+  });
+
+  it('OK @200 unauthenticated', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user.token).as('token');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    // When
+    cy.then(function () {
+      cy.getRequest(`/api/articles/${this.slug}/comments`, undefined).then(
+        (response: Cypress.Response<{ comments: Comment[] }>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.comments.length).to.equal(0);
+        },
+      );
+    });
+  });
+});
+
+describe('@POST comments', () => {
+  it('OK @200', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.user.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    const comment = { body: 'Hello' };
+
+    // When
+    cy.then(function () {
+      cy.postRequest(`/api/articles/${this.slug}/comments`, { comment }, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.comment.body).to.equal(comment.body);
+          expect(response.body.comment).to.haveOwnProperty('id');
+          expect(response.body.comment).to.haveOwnProperty('createdAt');
+          expect(response.body.comment).to.haveOwnProperty('updatedAt');
+          expect(response.body.comment.author.username).to.equal(this.user.username);
+        },
+      );
+    });
+
+    cy.then(function () {
+      cy.getRequest(`/api/articles/${this.slug}/comments`, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.comments.length).to.equal(1);
+          expect(response.body.comments[0].body).to.equal(comment.body);
+          expect(response.body.comments[0]).to.haveOwnProperty('id');
+          expect(response.body.comments[0]).to.haveOwnProperty('createdAt');
+          expect(response.body.comments[0]).to.haveOwnProperty('updatedAt');
+          expect(response.body.comments[0].author.username).to.equal(this.user.username);
+        },
+      );
+    });
+  });
+
+  it('KO @401', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.user.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    const comment = { body: 'Hello' };
+
+    // When
+    cy.then(function () {
+      cy.postRequest(`/api/articles/${this.slug}/comments`, { comment }, undefined).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(401);
+          expect(response.body.message).to.equal('missing authorization credentials');
+        },
+      );
+    });
+  });
+
+  it('KO @422', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.user.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    const comment = { body: undefined };
+
+    // When
+    cy.then(function () {
+      cy.postRequest(`/api/articles/${this.slug}/comments`, { comment }, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(422);
+          expect(response.body.errors.body[0]).to.equal("can't be blank");
+        },
+      );
+    });
+  });
+});
+
+describe('@DELETE comments', () => {
+  it('OK @200', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.user.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    const comment = { body: `${Cypress.env('prefix')}${Date.now()}-1` };
+
+    cy.then(function () {
+      cy.postRequest(`/api/articles/${this.slug}/comments`, { comment }, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          expect(response.status).to.equal(200);
+          cy.wrap(response.body.comment.id).as('commentId');
+        },
+      );
+    });
+
+    const otherComment = { body: `${Cypress.env('prefix')}${Date.now()}-2` };
+
+    cy.then(function () {
+      cy.postRequest(
+        `/api/articles/${this.slug}/comments`,
+        { comment: otherComment },
+        this.user.token,
+      ).then((response: Cypress.Response<any>) => {
+        expect(response.status).to.equal(200);
+      });
+    });
+
+    // When
+    cy.then(function () {
+      cy.deleteRequest(
+        `/api/articles/${this.slug}/comments/${this.commentId}`,
+        this.user.token,
+      ).then((response: Cypress.Response<any>) => {
+        // Then
+        expect(response.status).to.equal(200);
+      });
+    });
+
+    cy.then(function () {
+      cy.getRequest(`/api/articles/${this.slug}/comments`, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.comments.length).to.equal(1);
+          expect(response.body.comments[0].body).to.equal(otherComment.body);
+        },
+      );
+    });
+  });
+
+  it('KO @401', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    cy.then(function () {
+      createArticle(
+        {
+          title: `${Cypress.env('prefix')}${Date.now()}`,
+          description: `${Cypress.env('prefix')}${Date.now()}`,
+          body: `${Cypress.env('prefix')}${Date.now()}`,
+          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+        },
+        this.user.token,
+      ).then((response: Cypress.Response<Article>) => {
+        cy.wrap(response.body.article.slug).as('slug');
+      });
+    });
+
+    const comment = { body: 'Hello' };
+
+    cy.then(function () {
+      cy.postRequest(`/api/articles/${this.slug}/comments`, { comment }, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          expect(response.status).to.equal(200);
+          cy.wrap(response.body.comment).as('comment');
+        },
+      );
+    });
+
+    // When
+    cy.then(function () {
+      cy.deleteRequest(`/api/articles/${this.slug}/comments/${this.comment.id}`, undefined).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(401);
+          expect(response.body.message).to.equal('missing authorization credentials');
+        },
+      );
+    });
+  });
+
+  it('KO @404', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    const nonExistingSlug = `${Cypress.env('prefix')}${Date.now()}-2`;
+
+    // When
+    cy.then(function () {
+      cy.deleteRequest(`/api/articles/${nonExistingSlug}/comments/1`, this.user.token).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(404);
         },
       );
     });

--- a/apps/api-testing-cypress/src/e2e/profile.cy.ts
+++ b/apps/api-testing-cypress/src/e2e/profile.cy.ts
@@ -44,16 +44,15 @@ describe('@POST follow user', () => {
       cy.wrap(response.body.user).as('user');
     });
 
+    const article = {
+      title: `${Cypress.env('prefix')}${Date.now()}`,
+      description: `${Cypress.env('prefix')}${Date.now()}`,
+      body: `${Cypress.env('prefix')}${Date.now()}`,
+      tagList: [`${Cypress.env('prefix')}${Date.now()}`],
+    };
+
     cy.then(function () {
-      createArticle(
-        {
-          title: `${Cypress.env('prefix')}${Date.now()}`,
-          description: `${Cypress.env('prefix')}${Date.now()}`,
-          body: `${Cypress.env('prefix')}${Date.now()}`,
-          tagList: [`${Cypress.env('prefix')}${Date.now()}`],
-        },
-        this.user.token,
-      );
+      createArticle(article, this.user.token);
     });
 
     registerUser({
@@ -71,6 +70,7 @@ describe('@POST follow user', () => {
           // Then
           expect(response.status).to.equal(200);
           expect(response.body.profile.following).to.equal(true);
+          expect(response.body.profile.username).to.equal(this.user.username);
         },
       );
     });
@@ -80,7 +80,31 @@ describe('@POST follow user', () => {
         (response: Cypress.Response<any>) => {
           // Then
           expect(response.status).to.equal(200);
+          expect(response.body.articlesCount).to.equal(1);
           expect(response.body.articles.length).to.equal(1);
+          expect(response.body.articles[0].title).to.equal(article.title);
+          expect(response.body.articles[0].description).to.equal(article.description);
+          expect(response.body.articles[0].body).to.equal(article.body);
+          expect(response.body.articles[0].tagList).to.deep.equal(article.tagList);
+          expect(response.body.articles[0].author.username).to.equal(this.user.username);
+        },
+      );
+    });
+  });
+
+  it('KO @401', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    // When
+    cy.then(function () {
+      cy.postRequest(`/api/profiles/${this.user.username}/follow`, {}, undefined).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(401);
+          expect(response.body.message).to.equal('missing authorization credentials');
         },
       );
     });
@@ -113,6 +137,33 @@ describe('@DELETE unfollow user', () => {
           // Then
           expect(response.status).to.equal(200);
           expect(response.body.profile.following).to.equal(false);
+          expect(response.body.profile.username).to.equal(this.user.username);
+        },
+      );
+
+      cy.getRequest(`/api/profiles/${this.user.username}`, this.followerToken).then(
+        (response: Cypress.Response<Profile>) => {
+          // Then
+          expect(response.status).to.equal(200);
+          expect(response.body.profile.following).to.equal(false);
+        },
+      );
+    });
+  });
+
+  it('KO @401', () => {
+    // Given
+    registerUser().then((response: Cypress.Response<User>) => {
+      cy.wrap(response.body.user).as('user');
+    });
+
+    // When
+    cy.then(function () {
+      cy.deleteRequest(`/api/profiles/${this.user.username}/follow`, undefined).then(
+        (response: Cypress.Response<any>) => {
+          // Then
+          expect(response.status).to.equal(401);
+          expect(response.body.message).to.equal('missing authorization credentials');
         },
       );
     });


### PR DESCRIPTION
Added more tests to Cypress API test suite to increase covered functionality, helpful when trying to follow TDD practices to create an API implementation. Also included some extra assertions to verify that app really stores data in a database. I made sure they match behavior of the reference api backend implementation.

<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 265b281</samp>

Improved the end-to-end testing of the user and profile APIs using Cypress. Added more scenarios and checks for the profile, articles, follow, and unfollow endpoints in `profile.cy.ts`. Added new tests for the login and update endpoints in `user.cy.ts`. Refactored some common code for clarity and reuse.

## Details

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 265b281</samp>

* Extract article object from createArticle function call and assign to constant for readability and reusability ([link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-460bf0ca94de763b331edb02be1905dc6c307f2cd497cfcccd7be0dab703cb42L47-R55))
* Add assertions to check profile username, articles data, and follow/unfollow status in profile endpoint tests ([link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-460bf0ca94de763b331edb02be1905dc6c307f2cd497cfcccd7be0dab703cb42R73), [link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-460bf0ca94de763b331edb02be1905dc6c307f2cd497cfcccd7be0dab703cb42L83-R111), [link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-460bf0ca94de763b331edb02be1905dc6c307f2cd497cfcccd7be0dab703cb42L116-R170))
* Add test cases to check 401 errors for missing authorization header in follow and unfollow endpoint tests ([link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-460bf0ca94de763b331edb02be1905dc6c307f2cd497cfcccd7be0dab703cb42L83-R111), [link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-460bf0ca94de763b331edb02be1905dc6c307f2cd497cfcccd7be0dab703cb42L116-R170))
* Add test case to check 403 error and validation message for incorrect password in login endpoint test ([link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-0ada4253e4e9823caf8c5a11d7e858836222e6565aa24011c9e0afc0f1ad37f8R153-R172))
* Move update endpoint test from `user.cy.ts` to `profile.cy.ts` and add assertions to check token and user data ([link](https://github.com/gothinkster/realworld/pull/1423/files?diff=unified&w=0#diff-0ada4253e4e9823caf8c5a11d7e858836222e6565aa24011c9e0afc0f1ad37f8L215-R247))
