### PR TITLE
feat(docs): add Vite Plugin to Remove .md Extensions from URLs

### DIFF
--- a/apps/documentation/astro.config.mjs
+++ b/apps/documentation/astro.config.mjs
@@ -1,8 +1,57 @@
 import {defineConfig} from 'astro/config';
 import starlight from '@astrojs/starlight';
 import tailwind from "@astrojs/tailwind";
-
 import react from "@astrojs/react";
+
+/**
+ * A Vite plugin that removes `.md` extensions from URLs during the build process.
+ *
+ * This plugin is useful when working with Markdown files in a static site generator
+ * like Astro or Vite. It allows URLs to be served without the `.md` extension in
+ * the final build, making the URLs cleaner (e.g., `/docs/page` instead of `/docs/page.md`).
+ *
+ * ## Example Usage
+ * ```js
+ * import { defineConfig } from 'astro/config';
+ *
+ * export default defineConfig({
+ *   vite: {
+ *     plugins: [removeMdExtension()],
+ *   },
+ * });
+ * ```
+ *
+ * @typedef {object} VitePlugin
+ * @property {string} name - The name of the plugin, in this case, `remove-md-extension`.
+ * @property {string} enforce - Specifies the plugin's enforcement stage, set to `pre`
+ * to ensure that this plugin runs before other transformations during the build.
+ * @property {function} transform - The function that processes each file, removing
+ * `.md` extensions from the file content. It is called on every file during the build process.
+ *
+ * @returns {VitePlugin} A Vite-compatible plugin object that contains the `name`,
+ * `enforce`, and `transform` properties, implementing the plugin functionality.
+ *
+ * ## Vite Plugin Object Structure
+ * - `name`: The name of the plugin (`remove-md-extension`).
+ * - `enforce`: Ensures the plugin runs early (`pre` stage).
+ * - `transform(code: string, id: string): string`: The function that processes the content of `.md` files.
+ *
+ * @param {string} code - The content of the file being processed (e.g., the raw Markdown).
+ * @param {string} id - The file identifier (usually the file path), used to check if the file ends in `.md`.
+ * @returns {string} The modified file content, with any `.md` extensions in URLs removed.
+ */
+function removeMdExtension() {
+    return {
+        name: 'remove-md-extension',
+        enforce: 'pre',
+        transform(code, id) {
+            if (id.endsWith('.md')) {
+                return code.replace(/\.md/g, '');
+            }
+            return code;
+        },
+    };
+};
 
 // https://astro.build/config
 export default defineConfig({
@@ -121,5 +170,8 @@ export default defineConfig({
         ]
     }), tailwind({
         applyBaseStyles: false,
-    })]
+    })],
+    vite: {
+        plugins: [removeMdExtension()],
+    }
 });


### PR DESCRIPTION
## Description
This PR introduces a custom Vite plugin that removes `.md` file extensions from URLs during the build process. This fix addresses the common issue of **404 errors** due to Markdown links containing `.md` extensions.

closes #1564 

<img width="826" alt="image" src="https://github.com/user-attachments/assets/45270aaf-9d8f-4a20-b011-a03ad5dafeb9">

## Motivation
In Astro and Vite projects, links to Markdown files often include the `.md` extension. This plugin automatically removes `.md` extensions from internal URLs, ensuring clean and functional links like `/specifications/backend/api-response-format#users-for-authentication` instead of `/specifications/backend/api-response-format.md#users-for-authentication`.

## Benefits
- Automatically fixes broken links caused by `.md` extensions.
- Provides user-friendly URLs without `.md`.
- Seamlessly integrates into your Vite or Astro project.

This plugin ensures that all internal links remain functional and clean, improving both user experience and SEO.

<!-- RealWorld is currently testing GitHub Copilot for Pull Requests, please leave this template unchanged -->

## Summary

copilot:summary

## Details

copilot:walkthrough
