### PR TITLE
fix(specs): correct broken API spec link in backend docs

### DIFF
--- a/apps/documentation/src/content/docs/introduction.mdx
+++ b/apps/documentation/src/content/docs/introduction.mdx
@@ -8,7 +8,7 @@ title: Introduction
     <img src={'/img/conduit_l.png'} align="right" width="250px" />
 </a>
 
-> See how _the exact same_ Medium.com clone is built using different [frontends](https://codebase.show/projects/realworld?category=frontend) and [backends](https://codebase.show/projects/realworld?category=backend). Yes, you can mix and match them, because **they all adhere to the same [API spec](specs/backend-specs/introduction)** 😮😎
+> See how _the exact same_ Medium.com clone is built using different [frontends](https://codebase.show/projects/realworld?category=frontend) and [backends](https://codebase.show/projects/realworld?category=backend). Yes, you can mix and match them, because **they all adhere to the same [API spec](https://realworld-docs.netlify.app/specifications/backend/introduction/)** 😮😎
 
 While most "todo" demos provide an excellent cursory glance at a framework's capabilities, they typically don't convey the knowledge & perspective required to actually build _real_ applications with it.
 


### PR DESCRIPTION
## What was fixed
The API documentation link was broken and returned a 404 error.

## What was changed
Updated the link:
[API spec](specs/backend-specs/introduction/)  
⬇️  
[API spec](https://realworld-docs.netlify.app/specifications/backend/introduction/)

## Notes
This is a small documentation fix. No logic or code files were changed.
